### PR TITLE
[Feature] allow custom modal class and spotlight classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,12 +62,16 @@ Template.foo.helpers({
     id: "myCoolTutorial",
     steps: tutorialSteps,
     emitter: new EventEmitter(),
+    modalClass: "myFancyModalClass",
+    spotlightClass: "myFancySpotlightClass",
     onFinish: function() { /* make the tutorial disappear */ }
   }
 });
 ```
 
 The `id` field of the options is optional. If provided, it preserves the current step of the tutorial across a hot code reload by saving it in a `Session` variable. You will probably find this very useful when testing your tutorial.
+
+The `modalClass`, `spotlightClass` allows you to add your custom class to override the defaults.
 
 The steps of the tutorial should be an array of objects, which take the following form:
 

--- a/helpers.coffee
+++ b/helpers.coffee
@@ -48,6 +48,12 @@ Template.tutorial.helpers
     # This function is reactive; the above will run whenever the context changes
     return @currentTemplate()
 
+  modalClass: ->
+    return @currentModalClass
+
+  spotlightClass: ->
+    return @currentSpotlightClass
+
 Template._tutorial_buttons.events =
   "click .action-tutorial-back": -> @prev()
   "click .action-tutorial-next": -> @next()

--- a/templates.html
+++ b/templates.html
@@ -1,8 +1,8 @@
 <template name="tutorial">
     {{#with tutorialManager}}
-    <div class="spotlight"></div>
+    <div class="spotlight {{spotlightClass}}"></div>
     {{! Note the canonical BS3 div.modal wrapper is omitted here because it's actually NOT modal }}
-    <div class="modal-dialog positioned">
+    <div class="modal-dialog positioned {{modalClass}}">
         <div class="modal-content">
             <div class="modal-body">
                 {{> content }}

--- a/tutorial.coffee
+++ b/tutorial.coffee
@@ -26,6 +26,8 @@ class @TutorialManager
     @steps = options.steps
     @onFinish = options.onFinish || null
     @emitter = options.emitter
+    @currentModalClass = options.modalClass
+    @currentSpotlightClass = options.spotlightClass
 
     # Grab existing step if it exists - but don't grab it reactively,
     # or this template will keep reloading


### PR DESCRIPTION
<pre>
Template.foo.helpers({
  options: {
    id: "myCoolTutorial",
    steps: tutorialSteps,
    emitter: new EventEmitter(),
    <b>modalClass: "myFancyModalClass",
    spotlightClass: "myFancySpotlightClass",</b>
    onFinish: function() { /* make the tutorial disappear */ }
  }
});
</pre>

Allow for custom classes to override the default ui.