### PR TITLE
Meteor's stylus package is deprecated

### DIFF
--- a/package.js
+++ b/package.js
@@ -8,7 +8,7 @@ Package.describe({
 Package.onUse(function (api) {
   api.versionsFrom("1.2.0.1");
 
-  api.use(['jquery', 'stylus', 'coffeescript'], 'client');
+  api.use(['jquery', 'coagmano:stylus', 'coffeescript'], 'client');
   api.use(['ui', 'templating'], 'client');
 
   // Weak dependencies on the most popular bootstrap packages


### PR DESCRIPTION
Update to @hwillson's recommended version
see https://github.com/meteor/meteor/pull/9445